### PR TITLE
Remove obsolete System Updates menue

### DIFF
--- a/res/xml/device_info_settings.xml
+++ b/res/xml/device_info_settings.xml
@@ -16,23 +16,7 @@
 
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
         android:title="@string/about_settings">
-
-        <!-- System update settings - launches activity -->
-        <PreferenceScreen android:key="system_update_settings"
-                android:title="@string/system_update_settings_list_item_title" 
-                android:summary="@string/system_update_settings_list_item_summary">
-            <intent android:action="android.settings.SYSTEM_UPDATE_SETTINGS"
-                    android:targetPackage="com.cyanogenmod.fota"
-                    android:targetClass="com.cyanogenmod.fota.SystemUpdateActivity" />
-        </PreferenceScreen>
-
-        <PreferenceScreen android:key="additional_system_update_settings"
-                          android:title="@string/additional_system_update_settings_list_item_title">
-            <intent android:action="android.intent.action.MAIN"
-                    android:targetPackage="@string/additional_system_update"
-                    android:targetClass="@string/additional_system_update_menu" />
-        </PreferenceScreen>
-
+        
         <!-- Device status - launches activity -->
         <PreferenceScreen android:key="status_info"
                 android:title="@string/device_status" 


### PR DESCRIPTION
System update is not working on Sprint/Virgin Mobile builds.
