### PR TITLE
Can't add tiles if delete the tiles twice when no any tiles in QuickSettingsTiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+android_packages_apps_Settings
+==============================
+I will find and fix bugs of the project. 

--- a/src/com/android/settings/quicksettings/QuickSettingsUtil.java
+++ b/src/com/android/settings/quicksettings/QuickSettingsUtil.java
@@ -329,8 +329,12 @@ public class QuickSettingsUtil {
             return "";
         } else {
             String s = tiles.get(0);
-            for (int i = 1; i < tiles.size(); i++) {
-                s += TILE_DELIMITER + tiles.get(i);
+            if ("".equals(s)) {
+                s = tiles.get(1);
+            } else {
+                for (int i = 1; i < tiles.size(); i++) {
+                    s += TILE_DELIMITER + tiles.get(i);
+                }
             }
             return s;
         }


### PR DESCRIPTION
Firstly, delete all tiles in quick settings. Add one tiles then delete it. Add the tiles twice then delete it. Click add menu then the tile is gray and can't add.
