### PR TITLE
Move Color Values to Resource File

### DIFF
--- a/res/values/cm_colors.xml
+++ b/res/values/cm_colors.xml
@@ -23,11 +23,15 @@
     <color name="linear_color_bar_gray_color">#ff555555</color>
     <color name="linear_color_bar_white_color">#ffffffff</color>
 
+    <color name="data_usage_grid_label_color">#ff33b5e5</color>
+    <color name="data_usage_grid_stroke_color">#ff33b5e5</color>
     <color name="data_usage_series_fill_color">#c033b5e5</color>
     <color name="data_usage_series_fill_color_secondary">#6633b5e5</color>
     <color name="data_usage_series_stroke_color">#d88d3a</color>
     <color name="data_usage_series_details_fill_color">#c0ba7f3e</color>
     <color name="data_usage_series_details_fill_color_secondary">#60ba7f3e</color>
+    <color name="data_usage_series_details_pie_background_color">#ff666666</color>
+    <color name="data_usage_series_details_pie_foreground_color">#ffd88d3a</color>
     <color name="data_usage_sweep_warning_label_color">#f7931d</color>
     <color name="data_usage_sweep_limit_label_color">#c01a2c</color>
 </resources>


### PR DESCRIPTION
Move color values to the colors resource file to allow custom theme colors for the Settings > Data usage screen.
