### PR TITLE
Fix null reference when onOffChangeable == false

### DIFF
--- a/src/com/android/settings/notificationlight/LightSettingsDialog.java
+++ b/src/com/android/settings/notificationlight/LightSettingsDialog.java
@@ -248,7 +248,11 @@ public class LightSettingsDialog extends AlertDialog implements
 
     @SuppressWarnings("unchecked")
     public int getPulseSpeedOn() {
-        return ((Pair<String, Integer>) mPulseSpeedOn.getSelectedItem()).second;
+	if(mPulseSpeedOn.isEnabled()) {
+	    return ((Pair<String, Integer>) mPulseSpeedOn.getSelectedItem()).second;
+        }else {
+	    return 1;
+        }
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
java.lang.NullPointerException: Attempt to read from field 'java.lang.Object android.util.Pair.second' on a null object reference
at com.android.settings.notificationlight.LightSettingsDialog.getPulseSpeedOn(LightSettingsDialog.java:251)
at com.android.settings.notificationlight.ApplicationLightPreference$1.onClick(ApplicationLightPreference.java:177)
