### PR TITLE
Error in Italian translation

### DIFF
--- a/res/values-it/strings.xml
+++ b/res/values-it/strings.xml
@@ -2650,7 +2650,7 @@
     <string name="device_feedback" msgid="3238056036766293294">"Invia feedback sul dispositivo"</string>
     <string name="restr_pin_enter_admin_pin" msgid="2451187374960131018">"Inserisci PIN amministratore"</string>
     <string name="switch_on_text" msgid="1124106706920572386">"Attivo"</string>
-    <string name="switch_off_text" msgid="1139356348100829659">"Non attiva"</string>
+    <string name="switch_off_text" msgid="1139356348100829659">"Non attivo"</string>
     <string name="screen_pinning_title" msgid="2292573232264116542">"Blocco su schermo"</string>
     <string name="screen_pinning_description" msgid="1137904524037468263">"Quando l\'impostazione è attiva, puoi utilizzare il blocco su schermo per lasciare visibile la schermata corrente finché la sblocchi.\n\nPer usare la funzione:\n\n1. Assicurati che il blocco su schermo sia attivo.\n\n2. Apri la schermata da bloccare.\n\n3. Tocca Panoramica.\n\n4. Scorri in alto e tocca l\'icona di blocco."</string>
     <string name="screen_pinning_unlock_pattern" msgid="8282268570060313339">"Richiedi sequenza di sblocco prima di sbloccare"</string>


### PR DESCRIPTION
There is inconsistency between the terms "Attivo" (on) and "Non attiva" (off), in Italian we associate the adjectives to male or female nouns, in this case the correct form should be "Attivo" and "Non attivo" as it was in CM 12.1. Please fix it also in stable channel, thank you so much :)

CM13: <string name="switch_off_text" msgid="1139356348100829659">"Non attiva"</string> _wrong_
CM 12.1: <string name="switch_off_text" msgid="1139356348100829659">"Non attivo"</string>
